### PR TITLE
Add ls equivalent to the explorer type

### DIFF
--- a/explorer/explorer_operations.go
+++ b/explorer/explorer_operations.go
@@ -18,8 +18,9 @@ import (
 	"os"
 )
 
-// List returns the contents of the directory which the explorer is currently in.
-func (e *explorer) List() ([]string, error) {
+// List returns the contents of the directory which the explorer is currently in. Given a bool,
+// if true it will include files and directories prefixed with a '.', otherwise it will not.
+func (e *explorer) List(listAll bool) ([]string, error) {
 	var contents []string
 	f, err := os.Open(e.Path)
 	if err != nil {
@@ -31,16 +32,25 @@ func (e *explorer) List() ([]string, error) {
 		return contents, err
 	}
 
-	for _, file := range fileInfo {
-		contents = append(contents, file.Name())
+	if listAll {
+		for _, file := range fileInfo {
+			contents = append(contents, file.Name())
+		}
+	} else {
+		for _, file := range fileInfo {
+			if file.Name()[0] != '.' {
+				contents = append(contents, file.Name())
+			}
+		}
 	}
 	return contents, nil
 }
 
 // ListDirectories returns all directories within the current directory in which the explorer is
 // located. Note that this function will return an array of directories exclusively. Files will
-// be ignored.
-func (e *explorer) ListDirectories() ([]string, error) {
+// be ignored. Given a bool, if true it will include directories with a leading '.', otherwise it
+// will not.
+func (e *explorer) ListDirectories(listAll bool) ([]string, error) {
 	var directories []string
 	f, err := os.Open(e.Path)
 	if err != nil {
@@ -52,9 +62,17 @@ func (e *explorer) ListDirectories() ([]string, error) {
 		return directories, err
 	}
 
-	for _, file := range fileInfo {
-		if file.IsDir() {
-			directories = append(directories, file.Name())
+	if listAll {
+		for _, file := range fileInfo {
+			if file.IsDir() {
+				directories = append(directories, file.Name())
+			}
+		}
+	} else {
+		for _, file := range fileInfo {
+			if file.IsDir() && file.Name()[0] != '.' {
+				directories = append(directories, file.Name())
+			}
 		}
 	}
 	return directories, nil
@@ -62,7 +80,8 @@ func (e *explorer) ListDirectories() ([]string, error) {
 
 // ListFiles returns all files within the current directory in which the explorer is located. Note
 // that this function will return an array of files exclusively. No directory will be included.
-func (e *explorer) ListFiles() ([]string, error) {
+// Given a bool, if true it will include files prefixed with a '.', otherwise it will not.
+func (e *explorer) ListFiles(listAll bool) ([]string, error) {
 	var files []string
 	f, err := os.Open(e.Path)
 	if err != nil {
@@ -74,9 +93,17 @@ func (e *explorer) ListFiles() ([]string, error) {
 		return files, err
 	}
 
-	for _, file := range fileInfo {
-		if !file.IsDir() {
-			files = append(files, file.Name())
+	if listAll {
+		for _, file := range fileInfo {
+			if !file.IsDir() {
+				files = append(files, file.Name())
+			}
+		}
+	} else {
+		for _, file := range fileInfo {
+			if !file.IsDir() && file.Name()[0] != '.' {
+				files = append(files, file.Name())
+			}
 		}
 	}
 	return files, nil

--- a/explorer/explorer_operations.go
+++ b/explorer/explorer_operations.go
@@ -1,0 +1,83 @@
+// Copyright 2019 Max Godfrey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package explorer
+
+import (
+	"os"
+)
+
+// List returns the contents of the directory which the explorer is currently in.
+func (e *explorer) List() ([]string, error) {
+	var contents []string
+	f, err := os.Open(e.Path)
+	if err != nil {
+		return contents, err
+	}
+	fileInfo, err := f.Readdir(0)
+	f.Close()
+	if err != nil {
+		return contents, err
+	}
+
+	for _, file := range fileInfo {
+		contents = append(contents, file.Name())
+	}
+	return contents, nil
+}
+
+// ListDirectories returns all directories within the current directory in which the explorer is
+// located. Note that this function will return an array of directories exclusively. Files will
+// be ignored.
+func (e *explorer) ListDirectories() ([]string, error) {
+	var directories []string
+	f, err := os.Open(e.Path)
+	if err != nil {
+		return directories, err
+	}
+	fileInfo, err := f.Readdir(0)
+	f.Close()
+	if err != nil {
+		return directories, err
+	}
+
+	for _, file := range fileInfo {
+		if file.IsDir() {
+			directories = append(directories, file.Name())
+		}
+	}
+	return directories, nil
+}
+
+// ListFiles returns all files within the current directory in which the explorer is located. Note
+// that this function will return an array of files exclusively. No directory will be included.
+func (e *explorer) ListFiles() ([]string, error) {
+	var files []string
+	f, err := os.Open(e.Path)
+	if err != nil {
+		return files, err
+	}
+	fileInfo, err := f.Readdir(0)
+	f.Close()
+	if err != nil {
+		return files, err
+	}
+
+	for _, file := range fileInfo {
+		if !file.IsDir() {
+			files = append(files, file.Name())
+		}
+	}
+	return files, nil
+}

--- a/explorer/explorer_operations_test.go
+++ b/explorer/explorer_operations_test.go
@@ -1,0 +1,40 @@
+// Copyright 2019 Max Godfrey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package explorer
+
+import (
+	"testing"
+)
+
+func TestList(t *testing.T) {
+	e := New()
+	e.MoveAbsolute("~")
+	all, _ := e.List()
+	t.Log(all)
+}
+
+func TestListDirectories(t *testing.T) {
+	e := New()
+	e.MoveAbsolute("~")
+	directories, _ := e.ListDirectories()
+	t.Log(directories)
+}
+
+func TestListFiles(t *testing.T) {
+	e := New()
+	e.MoveAbsolute("~")
+	files, _ := e.ListFiles()
+	t.Log(files)
+}

--- a/explorer/explorer_operations_test.go
+++ b/explorer/explorer_operations_test.go
@@ -21,20 +21,26 @@ import (
 func TestList(t *testing.T) {
 	e := New()
 	e.MoveAbsolute("~")
-	all, _ := e.List()
+	all, _ := e.List(false)
+	t.Log(all)
+	all, _ = e.List(true)
 	t.Log(all)
 }
 
 func TestListDirectories(t *testing.T) {
 	e := New()
 	e.MoveAbsolute("~")
-	directories, _ := e.ListDirectories()
+	directories, _ := e.ListDirectories(false)
+	t.Log(directories)
+	directories, _ = e.ListDirectories(true)
 	t.Log(directories)
 }
 
 func TestListFiles(t *testing.T) {
 	e := New()
 	e.MoveAbsolute("~")
-	files, _ := e.ListFiles()
+	files, _ := e.ListFiles(false)
+	t.Log(files)
+	files, _ = e.ListFiles(true)
 	t.Log(files)
 }


### PR DESCRIPTION
Three new functions have been defined, they all have similar functions:
- `List` will return the contents of a directory
- `ListDirectories` will return all directories in the current directory
- `ListFiles` will return every item in a directory that is not a directory

These functions all take a boolean value as a parameter. If it is true, they will include items which are prefixed by a `.`. Otherwise (if the value is false), they will not.