### PR TITLE
Add package textrenderer

### DIFF
--- a/textrenderer/textrenderer.go
+++ b/textrenderer/textrenderer.go
@@ -14,10 +14,43 @@
 
 package textrenderer
 
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
 type textrenderer struct {
 	Text []string
 }
 
+// TerminalDimensions obtains the dimensions of the current terminal window and returns them.
+// Dimensions are returned with height first and width second. An error is also returned.
+func (t *textrenderer) TerminalDimensions() (int, int, error) {
+	rowsOutput, err := exec.Command("tput", "lines").Output()
+	if err != nil {
+		return -1, -1, err
+	}
+	height, _ := strconv.Atoi(strings.TrimRight(string(rowsOutput), " \n"))
+
+	columnsOutput, err := exec.Command("tput", "cols").Output()
+	if err != nil {
+		return -1, -1, err
+	}
+	width, _ := strconv.Atoi(strings.TrimRight(string(columnsOutput), " \n"))
+
+	return height, width, nil
+}
+
+// ClearScreen clears the terminal screen.
+func (t *textrenderer) ClearScreen() {
+	cmd := exec.Command("clear")
+	cmd.Stdout = os.Stdout
+	cmd.Run()
+}
+
+// New returns a new instance of the textrenderer type.
 func New() (t textrenderer) {
 	return
 }

--- a/textrenderer/textrenderer.go
+++ b/textrenderer/textrenderer.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Max Godfrey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textrenderer
+
+type textrenderer struct {
+	Text []string
+}
+
+func New() (t textrenderer) {
+	return
+}

--- a/textrenderer/textrenderer_test.go
+++ b/textrenderer/textrenderer_test.go
@@ -22,3 +22,13 @@ func TestNew(t *testing.T) {
 	tr := New()
 	t.Log(tr.Text)
 }
+
+func TestTerminalDimensions(t *testing.T) {
+	tr := New()
+	height, width, err := tr.TerminalDimensions()
+	if err == nil {
+		t.Log("Height:", height, "Width:", width)
+	} else {
+		t.Fatal("ERROR:", err)
+	}
+}

--- a/textrenderer/textrenderer_test.go
+++ b/textrenderer/textrenderer_test.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Max Godfrey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textrenderer
+
+import (
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tr := New()
+	t.Log(tr.Text)
+}


### PR DESCRIPTION
A new package, `textrenderer`, has been created. It will allow the file manager to render text on the terminal screen.

So far, it has very limited functionality - it can only clear the terminal screen and report the terminal's dimensions in terms of character width and height.