### PR TITLE
Render on terminal resize

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,9 @@ const (
 	// file system.
 	Move
 
+	// Resize represents a resize of the terminal window.
+	Resize
+
 	// Quit represents the termination of the application.
 	Quit
 )
@@ -58,9 +61,10 @@ var (
 	keypressChan = make(chan keypress)
 )
 
-// listenForKeypress indefinitely listens for keyboard input, and sends it to a specified channel.
+// listenForEvents indefinitely listens for termbox events. Any events that take the form of
+// keyboard input are sent to a specified channel, where they will be proecessed externally.
 // Note that ths method is intended to be called asynchronously (ie. as a goroutine).
-func listenForKeypress(ch chan keypress) {
+func listenForEvents(ch chan keypress) {
 	termbox.SetInputMode(termbox.InputEsc)
 
 	for {
@@ -81,6 +85,8 @@ func listenForKeypress(ch chan keypress) {
 			}
 		case termbox.EventError:
 			panic(ev.Err)
+		case termbox.EventResize:
+			screen.Render()
 		}
 	}
 }
@@ -153,7 +159,7 @@ func startExplorer() {
 		panic(err)
 	}
 
-	go listenForKeypress(keypressChan)
+	go listenForEvents(keypressChan)
 
 mainloop:
 	for {

--- a/main.go
+++ b/main.go
@@ -32,9 +32,6 @@ const (
 	// file system.
 	Move
 
-	// Resize represents a resize of the terminal window.
-	Resize
-
 	// Quit represents the termination of the application.
 	Quit
 )
@@ -136,9 +133,7 @@ func reselect(ev keypress) {
 	} else if newIndex < screen.StartIndex {
 		screen.StartIndex--
 	}
-	if err := screen.Render(); err != nil {
-		panic(err)
-	}
+	screen.Render()
 }
 
 // startExplorer runs the file manager until a Quit event is sent.

--- a/textrenderer/textrenderer.go
+++ b/textrenderer/textrenderer.go
@@ -60,15 +60,13 @@ func (t *textrenderer) Display(header string, text []string) error {
 	t.SelectedIndex = 0
 	t.StartIndex = 0
 
-	if err := t.Render(); err != nil {
-		return err
-	}
+	t.Render()
 	return nil
 }
 
 // Render displays the selected window of text and respective header on the terminal screen. The
 // selected file will be displayed with a caret, indicative of its selection.
-func (t *textrenderer) Render() error {
+func (t *textrenderer) Render() {
 	termWidth, termHeight := termbox.Size()
 	if err := termbox.Clear(termbox.ColorDefault, termbox.ColorDefault); err != nil {
 		panic(err)
@@ -95,8 +93,6 @@ func (t *textrenderer) Render() error {
 		}
 	}
 	termbox.Flush()
-
-	return nil
 }
 
 // TextViewSize returns the dimensions of the box in which textrenderer.Text is stored

--- a/textrenderer/textrenderer_test.go
+++ b/textrenderer/textrenderer_test.go
@@ -29,9 +29,7 @@ func TestRender(t *testing.T) {
 	tr.SelectedIndex = 2
 	tr.StartIndex = 1
 
-	if err := tr.Render(); err != nil {
-		t.Fatal(err)
-	}
+	tr.Render()
 }
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
When the terminal is resized, render the current state of the explorer regardless of keyboard input.