### PR TITLE
Show file preview

### DIFF
--- a/explorer/explorer_operations.go
+++ b/explorer/explorer_operations.go
@@ -105,7 +105,6 @@ func (e *explorer) ListN(curSelected string, n int, listAll bool) ([]string, err
 	}
 
 	f, err := os.Open(e.Path + "/" + curSelected)
-	defer f.Close()
 	if err != nil {
 		if strings.HasSuffix(err.Error(), "denied") {
 			contents = append(contents, "PERMISSION DENIED")
@@ -113,6 +112,7 @@ func (e *explorer) ListN(curSelected string, n int, listAll bool) ([]string, err
 		}
 		return contents, err
 	}
+	defer f.Close()
 	if listAll {
 		fileInfo, err := f.Readdir(n)
 		if err != nil {
@@ -132,7 +132,10 @@ func (e *explorer) ListN(curSelected string, n int, listAll bool) ([]string, err
 		return contents, nil
 	}
 
-	fileInfo, err := f.Readdir(n)
+	fileInfo, err := f.Readdir(0)
+	if err != nil {
+		return contents, err
+	}
 	for _, file := range fileInfo {
 		if len(contents) == n {
 			break

--- a/explorer/explorer_operations.go
+++ b/explorer/explorer_operations.go
@@ -15,6 +15,7 @@
 package explorer
 
 import (
+	"bufio"
 	"os"
 )
 
@@ -123,4 +124,22 @@ func (e *explorer) ListFiles(listAll bool) ([]string, error) {
 		}
 	}
 	return files, nil
+}
+
+// ReadN reads the first N lines of a
+func (e *explorer) ReadN(fileName string, n int) ([]string, error) {
+	var contents []string
+	file, err := os.Open(e.Path + "/" + fileName)
+	if err != nil {
+		return contents, err
+	}
+
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+	for i := 0; i < n && scanner.Scan(); i++ {
+		contents = append(contents, scanner.Text())
+	}
+
+	file.Close()
+	return contents, nil
 }

--- a/main.go
+++ b/main.go
@@ -38,6 +38,9 @@ const (
 
 	// Quit represents the termination of the application.
 	Quit
+
+	// NullEvent represents a dud event passed as a nil equivalent
+	NullEvent
 )
 
 // Movement directions
@@ -93,7 +96,7 @@ func listenForEvents(ch chan keypress) {
 		case termbox.EventError:
 			panic(ev.Err)
 		case termbox.EventResize:
-			screen.Render()
+			screen.Render(genPreview())
 		}
 	}
 }
@@ -109,7 +112,8 @@ func move() {
 		if err != nil {
 			panic(nav.Path)
 		}
-		screen.Display(nav.Path+"/", dirContents)
+		screen.Init(nav.Path+"/", dirContents)
+		screen.Display(nav.Path+"/", dirContents, genPreview())
 	}
 }
 
@@ -124,6 +128,26 @@ func keyToDirection(key termbox.Key) int {
 	default:
 		return 0
 	}
+}
+
+// genPreview returns a preview of the current selected file or directory.
+func genPreview() []string {
+	curSelected := screen.CurrentSelected()
+	var err error
+	var preview []string
+	if curSelected[len(curSelected)-1] != '/' {
+		preview, err = nav.ReadN(curSelected, screen.PreviewHeight())
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		preview, err = nav.ListN(curSelected, screen.PreviewHeight(), listAll)
+		if err != nil {
+			panic("'" + err.Error() + "'")
+		}
+	}
+
+	return preview
 }
 
 // reselect moves the screen's display of files when the user presses either an up or down arrow
@@ -141,16 +165,7 @@ func reselect(ev keypress) {
 	} else if newIndex < screen.StartIndex {
 		screen.StartIndex--
 	}
-	screen.Render()
-
-	curSelected := screen.CurrentSelected()
-	if curSelected[len(curSelected)-1] != '/' {
-		preview, err := nav.ReadN(curSelected, screen.PreviewHeight())
-		if err != nil {
-			panic(err)
-		}
-		screen.RenderPreview(preview)
-	}
+	screen.Render(genPreview())
 }
 
 // startExplorer runs the file manager until a Quit event is sent.
@@ -167,7 +182,8 @@ func startExplorer() {
 	if err != nil {
 		panic(err)
 	}
-	screen.Display(nav.Path+"/", dirContents)
+	screen.Init(nav.Path+"/", dirContents)
+	screen.Display(nav.Path+"/", dirContents, genPreview())
 
 	go listenForEvents(keypressChan)
 
@@ -195,7 +211,8 @@ func toggleListAll() {
 	if err != nil {
 		panic(err)
 	}
-	screen.Display(nav.Path+"/", dirContents)
+	screen.Init(nav.Path+"/", dirContents)
+	screen.Display(nav.Path+"/", dirContents, genPreview())
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -142,6 +142,15 @@ func reselect(ev keypress) {
 		screen.StartIndex--
 	}
 	screen.Render()
+
+	curSelected := screen.CurrentSelected()
+	if curSelected[len(curSelected)-1] != '/' {
+		preview, err := nav.ReadN(curSelected, screen.PreviewHeight())
+		if err != nil {
+			panic(err)
+		}
+		screen.RenderPreview(preview)
+	}
 }
 
 // startExplorer runs the file manager until a Quit event is sent.

--- a/main.go
+++ b/main.go
@@ -38,9 +38,6 @@ const (
 
 	// Quit represents the termination of the application.
 	Quit
-
-	// NullEvent represents a dud event passed as a nil equivalent
-	NullEvent
 )
 
 // Movement directions

--- a/textrenderer/textrenderer_test.go
+++ b/textrenderer/textrenderer_test.go
@@ -29,7 +29,7 @@ func TestRender(t *testing.T) {
 	tr.SelectedIndex = 2
 	tr.StartIndex = 1
 
-	tr.Render()
+	tr.Render([]string{"no preview here..."})
 }
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
When a file or folder is hovered over, a preview of it is now displayed on the right hand side of the terminal screen.
This feature also displays a relevant message if an error relative to the file system occurs. For example, "PERMISSION DENIED" is shown with a red background if the user does not have the privileges to preview the selected file or folder.